### PR TITLE
fix username for direct messages

### DIFF
--- a/slck-protocol/hub.go
+++ b/slck-protocol/hub.go
@@ -104,7 +104,7 @@ func (h *hub) message(u string, r string, m []byte) {
 			}
 		case '@':
 			if user, ok := h.clients[r]; ok {
-				msg := append([]byte(user.username+": "), m...)
+				msg := append([]byte(sender.username+": "), m...)
 				msg = append(msg, '\n')
 
 				user.conn.Write(msg)

--- a/slck-protocol/hub.go
+++ b/slck-protocol/hub.go
@@ -28,7 +28,7 @@ func (h *hub) run() {
 		case client := <-h.registrations:
 			h.register(client)
 		case client := <-h.deregistrations:
-			h.unregister(client)
+			h.deregister(client)
 		case cmd := <-h.commands:
 			switch cmd.id {
 			case JOIN:


### PR DESCRIPTION
When UserA sends a direct message to UserB, it is better to print the username of UserA into the terminal of UserB. 

Includes #1 as well. 